### PR TITLE
Revisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 
 # C extensions
 *.so
+
+# Config File (incl. Passwords)
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ __pycache__/
 # C extensions
 *.so
 
-# Config File (incl. Passwords)
-config.json
+# All Data and the Config File (incl. Passwords)
+*.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # OpenReviewCrawler
 A Crawler for Open Review. 
+
+#Installation
+1. Get the current geckodriver for your operating system at the following domain:
+https://github.com/mozilla/geckodriver/releases
+
+2. Unpack the compressed file in your File System 
+
+3. Adjust the Path Variable in the config.json file at "geckodriver" according to your setup
+
+#Run
+Run the Programm with the configuration with the following command:
+python crawler.py -c config.json

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ https://github.com/mozilla/geckodriver/releases
 3. Adjust the Path Variable in the config.json file at "geckodriver" according to your setup
 
 #Run
-Run the Programm with the configuration with the following command:
-python crawler.py -c config.json
+Run the Programm with custom configuration-file with the following command:
+python crawler.py -c FILEPATH

--- a/config.json
+++ b/config.json
@@ -13,5 +13,6 @@
   "password": "",
   "outdir": ".",
   "filename": "out.json",
-  "json_indent": 3
+  "json_indent": 3,
+  "geckodriver": "/home/erikschwan/PycharmProjects/OpenReviewCrawler/geckodriver"
 }

--- a/crawler.py
+++ b/crawler.py
@@ -4,7 +4,11 @@ import os
 from datetime import date
 import re
 import openreview
+import requests
 
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+import selenium.webdriver.support.ui as ui
 
 def crawl(client, config):
     results = []
@@ -53,11 +57,38 @@ if __name__ == '__main__':
         venues = openreview.tools.get_all_venues(c)
         print(*venues, sep="\n")
 
-        for r in c.get_references(referent='ryQu7f-RZ'):
-            print(r)
+        my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
+        options = Options()
+        options.headless = True
+        driver = webdriver.Firefox(options=options, executable_path=r'/home/erikschwan/PycharmProjects/OpenReviewCrawler/geckodriver')
+        #driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
+        driver.get(my_url)
+        wait = ui.WebDriverWait(driver, 10)
+        wait.until(lambda driver: driver.find_element_by_class_name('row'))
+        print(driver.find_element_by_class_name('row'))
+        for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
+           print(elm.text)
+        #response = session.body()
+        #soup = BeautifulSoup(response)
+        #print(soup.find(id="note_Syax5XD9M"))
+        #response = c.__handle_response(response)
+        #for t in response.json()['tags']:
+        #   print(t)
 
     else:
         config = json.load(open(args.config))
+        my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
+        options = Options()
+        options.headless = True
+        driver = webdriver.Firefox(options=options,
+                                   executable_path=config['geckodriver'])
+        # driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
+        driver.get(my_url)
+        wait = ui.WebDriverWait(driver, 10)
+        wait.until(lambda driver: driver.find_element_by_class_name('row'))
+        print(driver.find_element_by_class_name('row'))
+        for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
+            print(elm.text)
 
         username = config["username"]
         if args.password is not None:

--- a/crawler.py
+++ b/crawler.py
@@ -44,14 +44,46 @@ def merge_invitations(invitations):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-c', '--config', help='configuration for the crawling')
+        '-c', '--config', help='configuration for the crawling', default='config.json')
     parser.add_argument(
         '-p', '--password', help='password for the username given in the config. Overwrites password in config')
     parser.add_argument('--baseurl', default='https://openreview.net')
 
     args = parser.parse_args()
 
+    try:
+        config = json.load(open(args.config))
+    except:
+        print('The configuration File has not been found. \n Please Make sure it is correctly Named \'config.json\' and is located in the project root foulder.\n Otherwise please specify the configuration Path with the parser argument \'-c PATH\'')
+
+    print("Available venues:")
+    c = openreview.Client(baseurl='https://openreview.net')
+    venues = openreview.tools.get_all_venues(c)
+    print(*venues, sep="\n")
+
+    my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
+    options = Options()
+    options.headless = True
+    try:
+        driver = webdriver.Firefox(options=options,
+                                   executable_path=config['geckodriver'])
+    except:
+        print('The webdriver has not been setup correctly! Please follow the README Installation instructions to setup the geckodriver.')
+
+
+    # driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
+    driver.get(my_url)
+    wait = ui.WebDriverWait(driver, 10)
+    wait.until(lambda driver: driver.find_element_by_class_name('row'))
+    print(driver.find_element_by_class_name('row'))
+
+    for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
+        print(elm.text)
+
+
+    '''
     if args.config is None:
+
         print("Available venues:")
         c = openreview.Client(baseurl='https://openreview.net')
         venues = openreview.tools.get_all_venues(c)
@@ -87,6 +119,7 @@ if __name__ == '__main__':
         wait = ui.WebDriverWait(driver, 10)
         wait.until(lambda driver: driver.find_element_by_class_name('row'))
         print(driver.find_element_by_class_name('row'))
+
         for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
             print(elm.text)
 
@@ -102,3 +135,4 @@ if __name__ == '__main__':
             password=password)
 
         crawl(client, config)
+        '''

--- a/crawler.py
+++ b/crawler.py
@@ -5,32 +5,57 @@ from datetime import date
 import re
 import openreview
 import requests
-
+import logging
+import sys
+import progressbar
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
 import selenium.webdriver.support.ui as ui
+import time
 
-def crawl(client, config):
+def crawl(client, config,log):
     results = []
+    driver  = start_webdriver()
     for target in config["targets"]:
         venue, years = target["venue"], target["years"]
         if years == "all":
             years = range(2000, date.today().year + 2)
         for year in years:
+            log.info('Current Download:'+ venue+' in '+str(year))
             invitations_iterator = openreview.tools.iterget_invitations(client, regex="{}/{}/".format(venue, year))
             invitations = [inv.id for inv in invitations_iterator]
             invitations = merge_invitations(invitations)
             if not invitations:
+                log.warning('No Data for'+ venue+' in '+str(year))
                 continue
             else:
                 invs = []
-                for inv in invitations:
+                for inv in progressbar.progressbar(invitations):
+                    notes = [note for note in openreview.tools.iterget_notes(client, invitation=inv)]
+                    revisions = []
+                    for n in notes:
+                        revisions.append(get_revisions(n.id,driver))
+
                     invs.append({"invitation": inv,
-                                        "notes": [note.to_json() for note in openreview.tools.iterget_notes(client, invitation=inv)]})
+                                        "notes": [note.to_json() for note in notes],
+                                 'revisions': [json.dumps(rev) for  rev in revisions if revisions]})
                 results.append({"venue": venue, "year": year, "invitations": invs})
 
     with open(os.path.join(config["outdir"], config["filename"]), 'w') as file_handle:
         json.dump(results, file_handle, indent=config["json_indent"])
+
+
+def start_webdriver():
+    options = Options()
+    options.headless = True
+    try:
+        driver = webdriver.Firefox(options=options,
+                                   executable_path=config['geckodriver'])
+    except:
+        print(
+            'The webdriver has not been setup correctly! Please follow the README Installation instructions to setup the geckodriver.')
+    return driver
+
 
 def merge_invitations(invitations):
     new_invitations = set()
@@ -40,8 +65,39 @@ def merge_invitations(invitations):
         new_invitations.add(sub2)
     return new_invitations
 
+def get_revisions(id,driver):
+    my_url = 'http://openreview.net/revisions?id='+id
+    driver.get(my_url)
+
+    wait = ui.WebDriverWait(driver, 10)
+    try:
+        wait.until(lambda driver: driver.find_element_by_class_name('note_content_pdf'))
+    except:
+        log.error(id+' id causes a timeout')
+
+    revisions = []
+    for revision in driver.find_elements_by_class_name('note'):
+        title = revision.find_element_by_class_name('note_content_title').text
+        try:
+            pdf = revision.find_element_by_class_name('note_content_pdf').get_attribute('href')
+        except:
+            pdf = 'NoPDF'
+            log.error(id + ' provides no PDF')
+            pass
+        authors = [p.text for p in revision.find_elements_by_class_name('profile-link')]
+        date = revision.find_element_by_class_name('date').text
+        notes = [p.text for p in revision.find_elements_by_class_name('note_contents')]
+        revisions.append({'title': title, 'pdf': pdf, 'authors': authors, 'date': date, 'pdf': pdf, 'notes': notes})
+
+    return revisions
+
+
 
 if __name__ == '__main__':
+    log = logging.getLogger("crawler")
+    log.setLevel(logging.INFO)
+    progressbar.streams.wrap_stderr()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-c', '--config', help='configuration for the crawling', default='config.json')
@@ -50,89 +106,30 @@ if __name__ == '__main__':
     parser.add_argument('--baseurl', default='https://openreview.net')
 
     args = parser.parse_args()
-
+    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
     try:
         config = json.load(open(args.config))
     except:
         print('The configuration File has not been found. \n Please Make sure it is correctly Named \'config.json\' and is located in the project root foulder.\n Otherwise please specify the configuration Path with the parser argument \'-c PATH\'')
 
+    '''
     print("Available venues:")
     c = openreview.Client(baseurl='https://openreview.net')
     venues = openreview.tools.get_all_venues(c)
     print(*venues, sep="\n")
-
-    my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
-    options = Options()
-    options.headless = True
-    try:
-        driver = webdriver.Firefox(options=options,
-                                   executable_path=config['geckodriver'])
-    except:
-        print('The webdriver has not been setup correctly! Please follow the README Installation instructions to setup the geckodriver.')
-
-
-    # driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
-    driver.get(my_url)
-    wait = ui.WebDriverWait(driver, 10)
-    wait.until(lambda driver: driver.find_element_by_class_name('row'))
-    print(driver.find_element_by_class_name('row'))
-
-    for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
-        print(elm.text)
-
-
     '''
-    if args.config is None:
 
-        print("Available venues:")
-        c = openreview.Client(baseurl='https://openreview.net')
-        venues = openreview.tools.get_all_venues(c)
-        print(*venues, sep="\n")
-
-        my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
-        options = Options()
-        options.headless = True
-        driver = webdriver.Firefox(options=options, executable_path=r'/home/erikschwan/PycharmProjects/OpenReviewCrawler/geckodriver')
-        #driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
-        driver.get(my_url)
-        wait = ui.WebDriverWait(driver, 10)
-        wait.until(lambda driver: driver.find_element_by_class_name('row'))
-        print(driver.find_element_by_class_name('row'))
-        for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
-           print(elm.text)
-        #response = session.body()
-        #soup = BeautifulSoup(response)
-        #print(soup.find(id="note_Syax5XD9M"))
-        #response = c.__handle_response(response)
-        #for t in response.json()['tags']:
-        #   print(t)
-
+    username = config["username"]
+    if args.password is not None:
+        password = args.password
     else:
-        config = json.load(open(args.config))
-        my_url = 'http://openreview.net/revisions?id=ryQu7f-RZ'
-        options = Options()
-        options.headless = True
-        driver = webdriver.Firefox(options=options,
-                                   executable_path=config['geckodriver'])
-        # driver = webdriver.PhantomJS('Resources/phantomjs-2.1.1-linux-x86_64/bin/phantomjs')
-        driver.get(my_url)
-        wait = ui.WebDriverWait(driver, 10)
-        wait.until(lambda driver: driver.find_element_by_class_name('row'))
-        print(driver.find_element_by_class_name('row'))
+        password = config["password"]
 
-        for elm in driver.find_elements_by_class_name('title_pdf_row clearfix'):
-            print(elm.text)
+    client = openreview.Client(
+        baseurl='https://openreview.net',
+        username=username,
+        password=password)
+    log.info('Login as '+username+' was successful')
 
-        username = config["username"]
-        if args.password is not None:
-            password = args.password
-        else:
-            password = config["password"]
+    crawl(client, config,log)
 
-        client = openreview.Client(
-            baseurl='https://openreview.net',
-            username=username,
-            password=password)
-
-        crawl(client, config)
-        '''

--- a/crawler.py
+++ b/crawler.py
@@ -53,6 +53,9 @@ if __name__ == '__main__':
         venues = openreview.tools.get_all_venues(c)
         print(*venues, sep="\n")
 
+        for r in c.get_references(referent='ryQu7f-RZ'):
+            print(r)
+
     else:
         config = json.load(open(args.config))
 


### PR DESCRIPTION
This Pull Request provides a working solution to access the revisions data (incl. the links to all pdf versions). This data is not accessible by the official openreview api package. Since the site loads the data with a script, I used a headless browser before scaping the data. I decided to use a "traditional crawler" since the official openreview api package, which we are using for all other tasks, also works with html requests. 